### PR TITLE
Fix duplicate shebang in manage.py

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
-#!/usr/bin/env python
 import os
 import sys
 


### PR DESCRIPTION
## Summary
- clean up `manage.py` by removing an accidental second shebang

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6840452639c0832abd31a9e6b81f19d4