### PR TITLE
Fix installed apps path

### DIFF
--- a/moodsinger/settings.py
+++ b/moodsinger/settings.py
@@ -47,7 +47,7 @@ INSTALLED_APPS = [
     'drf_yasg',
 
     # Local apps
-    'apps.authounts',                  # Use only the correct app name
+    'apps.acc',                  # Use only the correct app name
     'apps.music',
     'apps.analysis',
     'apps.feature_settings',


### PR DESCRIPTION
## Summary
- update installed apps path in the Django project settings

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'rest_framework')*

------
https://chatgpt.com/codex/tasks/task_e_68404a87ef28832aa80dc9dfd7c5a9f8