### PR TITLE
Fix account routing

### DIFF
--- a/apps/acc/urls.py
+++ b/apps/acc/urls.py
@@ -5,5 +5,4 @@ urlpatterns = [
     path('register/', views.register, name='register'),
     path('login/', views.login, name='login'),
     path('google/', views.google_auth, name='google-auth'),
-    path('api/auth/', include('apps.accounts.urls')), 
 ]

--- a/moodsinger/urls.py
+++ b/moodsinger/urls.py
@@ -34,7 +34,7 @@ schema_view = get_schema_view(
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('api/auth/', include('apps.auth.urls')),
+    path('api/auth/', include('apps.acc.urls')),
     path('api/music/', include('apps.music.urls')),
     path('api/analysis/', include('apps.analysis.urls')),
     path('api/feature-settings/', include('apps.feature_settings.urls')),


### PR DESCRIPTION
## Summary
- route account endpoints via `apps.acc.urls`
- remove incorrect nested include for accounts

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68404a920918832aa2cb5545e431c229