### PR TITLE
Fix update_settings URL path

### DIFF
--- a/apps/feature_settings/urls.py
+++ b/apps/feature_settings/urls.py
@@ -3,5 +3,5 @@ from . import views
 
 urlpatterns = [
     path('', views.get_settings, name='get-settings'),
-    path('', views.update_settings, name='update-settings'),
+    path('update/', views.update_settings, name='update-settings'),
 ]


### PR DESCRIPTION
## Summary
- assign dedicated URL for PUT requests to update feature settings

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'apps.authounts')*

------
https://chatgpt.com/codex/tasks/task_e_68404aa15f88832abec37dc692cad979