### PR TITLE
Fix settings variable names

### DIFF
--- a/moodsinger/settings.py
+++ b/moodsinger/settings.py
@@ -130,7 +130,7 @@ REST_FRAMEWORK = {
 
 # JWT Settings
 SIMPLE_JWT = {
-    'authESS_TOKEN_LIFETIME': timedelta(days=1),
+    'ACCESS_TOKEN_LIFETIME': timedelta(days=1),
     'REFRESH_TOKEN_LIFETIME': timedelta(days=7),
     'ROTATE_REFRESH_TOKENS': True,
     'BLACKLIST_AFTER_ROTATION': True,
@@ -145,7 +145,7 @@ CORS_ALLOWED_ORIGINS = [
 # Celery Configuration
 CELERY_BROKER_URL = config('REDIS_URL', default='redis://localhost:6379/0')
 CELERY_RESULT_BACKEND = config('REDIS_URL', default='redis://localhost:6379/0')
-CELERY_authEPT_CONTENT = ['json']
+CELERY_ACCEPT_CONTENT = ['json']
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
 


### PR DESCRIPTION
## Summary
- fix token lifetime variable name in `SIMPLE_JWT`
- fix Celery accept content variable name

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'celery')*

------
https://chatgpt.com/codex/tasks/task_e_68404aaa26dc832abdccdc6dbbd6edc6