### PR TITLE
Use env SECRET_KEY and document

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This repository contains the Django backend for the Moodsinger project.
 The application uses `python-decouple` to load configuration. Define the following variables in your `.env` file:
 
 ```
+SECRET_KEY=your-secret-key
 DEBUG=true
 ALLOWED_HOSTS=localhost,127.0.0.1
 DB_NAME=moodsinger_db

--- a/moodsinger/settings.py
+++ b/moodsinger/settings.py
@@ -26,8 +26,13 @@ import os
 from pathlib import Path
 from decouple import config
 from datetime import timedelta
+
 BASE_DIR = Path(__file__).resolve().parent.parent
-SECRET_KEY = 'django-insecure-gmk1maq&z&*t41ywdxnr)2no&7ve!8ymt!#84+xfn*0mbwf2hg'
+# SECRET_KEY should always be provided via environment variables in
+# production. A default value is supplied for local development only.
+SECRET_KEY = config(
+    'SECRET_KEY', default='django-insecure-change-me'
+)
 DEBUG = config('DEBUG', default=True, cast=bool)
 ALLOWED_HOSTS = config('ALLOWED_HOSTS', default='localhost,127.0.0.1', cast=lambda v: [s.strip() for s in v.split(',')])
 


### PR DESCRIPTION
## Summary
- load `SECRET_KEY` from the environment using `python-decouple`
- update README to document the new `SECRET_KEY` variable

## Testing
- `python -m py_compile moodsinger/settings.py`


------
https://chatgpt.com/codex/tasks/task_e_68404dd79124832ab088050eb2be7313